### PR TITLE
SPDX LICENSE: Add spdx License headers

### DIFF
--- a/meta-mion-simplerunc/recipes-core/image-json-file/image-json-file.bb
+++ b/meta-mion-simplerunc/recipes-core/image-json-file/image-json-file.bb
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 inherit allarch
 
 SUMMARY = "Create Mion image.json file"

--- a/meta-mion-simplerunc/recipes-core/images/mion-guest-onlpv1.bb
+++ b/meta-mion-simplerunc/recipes-core/images/mion-guest-onlpv1.bb
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "Mion ONLPv1 guest image recipe."
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"

--- a/meta-mion-simplerunc/recipes-core/images/mion-guest-onlpv2.bb
+++ b/meta-mion-simplerunc/recipes-core/images/mion-guest-onlpv2.bb
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "Mion ONLPv2 guest image recipe."
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"

--- a/meta-mion-simplerunc/recipes-core/images/mion-host.bb
+++ b/meta-mion-simplerunc/recipes-core/images/mion-host.bb
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "mion host image recipe."
 LICENSE = "MIT"
 

--- a/meta-mion-simplerunc/recipes-core/mion-image-packaging/mion-guest-onlpv1-pkg.bb
+++ b/meta-mion-simplerunc/recipes-core/mion-image-packaging/mion-guest-onlpv1-pkg.bb
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "Package onlpv1 container image"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"

--- a/meta-mion-simplerunc/recipes-core/mion-image-packaging/mion-guest-onlpv2-pkg.bb
+++ b/meta-mion-simplerunc/recipes-core/mion-image-packaging/mion-guest-onlpv2-pkg.bb
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "Package onlpv2 container image"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"

--- a/meta-mion-simplerunc/recipes-core/mion-local-feed/mion-local-feed.bb
+++ b/meta-mion-simplerunc/recipes-core/mion-local-feed/mion-local-feed.bb
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "Create a local feed of Mion guest images to allow offline creation of guests"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"

--- a/meta-mion-simplerunc/recipes-core/preconfig-guests/preconfig-guests.bb
+++ b/meta-mion-simplerunc/recipes-core/preconfig-guests/preconfig-guests.bb
@@ -1,5 +1,8 @@
+# SPDX-License-Identifier: MIT
+
 SUMMARY = "Create preconfigure script for guest(s)"
-LICENSE = "CLOSED"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 
 inherit allarch
 

--- a/meta-mion-simplerunc/recipes-core/srunc/srunc.bb
+++ b/meta-mion-simplerunc/recipes-core/srunc/srunc.bb
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 DESCRIPTION = "Simple Runc Application"
 HOMEPAGE = "https://mion.io/"
 LICENSE = "MIT"

--- a/meta-mion-simplerunc/recipes-core/start-scripts/files/start-sshd
+++ b/meta-mion-simplerunc/recipes-core/start-scripts/files/start-sshd
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+# SPDX-License-Identifier: MIT
+
 set -e
 
 # Initialise tmpfs directories

--- a/meta-mion-simplerunc/recipes-core/start-scripts/start-sshd.bb
+++ b/meta-mion-simplerunc/recipes-core/start-scripts/start-sshd.bb
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 DESCRIPTION = "Start script for sshd"
 HOMEPAGE = "https://www.mion.io"
 LICENSE = "MIT"

--- a/meta-mion-simplerunc/recipes-devtools/python/python3-betatest.bb
+++ b/meta-mion-simplerunc/recipes-devtools/python/python3-betatest.bb
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 DESCRIPTION = "Testing helpers for Python 3.6+"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d229da563da18fe5d58cd95a6467d584"

--- a/meta-mion/recipes-core/images/mion-image-onlpv1.bb
+++ b/meta-mion/recipes-core/images/mion-image-onlpv1.bb
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 require mion-image-core.inc
 ONLPV="onlpv1"
 IMAGE_INSTALL += " onlpv1"

--- a/meta-mion/recipes-core/images/mion-image-onlpv2.bb
+++ b/meta-mion/recipes-core/images/mion-image-onlpv2.bb
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 require mion-image-core.inc
 ONLPV="onlpv2"
 IMAGE_INSTALL += " onlpv2"

--- a/meta-mion/recipes-core/os-release/os-release.bbappend
+++ b/meta-mion/recipes-core/os-release/os-release.bbappend
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 OS_RELEASE_FIELDS_append_mion = " \

--- a/meta-mion/recipes-onie/images/mion-onie-image-onlpv1.bb
+++ b/meta-mion/recipes-onie/images/mion-onie-image-onlpv1.bb
@@ -1,2 +1,4 @@
+# SPDX-License-Identifier: MIT
+
 require mion-onie-image.inc
 ONLPV="onlpv1"

--- a/meta-mion/recipes-onie/images/mion-onie-image-onlpv2.bb
+++ b/meta-mion/recipes-onie/images/mion-onie-image-onlpv2.bb
@@ -1,2 +1,4 @@
+# SPDX-License-Identifier: MIT
+
 require mion-onie-image.inc
 ONLPV="onlpv2"

--- a/meta-mion/recipes-onie/onie-tools/onie-tools/onie-bisdn-rescue
+++ b/meta-mion/recipes-onie/onie-tools/onie-tools/onie-bisdn-rescue
@@ -3,6 +3,8 @@
 # Copyright (C) 2019 Daniel Fritzsche of BISDN GmbH
 # Bash script to boot into ONIE: rescue.
 
+# SPDX-License-Identifier: MIT
+
 set -e
 
 USAGE="Boot into ONIE rescue mode

--- a/meta-mion/recipes-onie/onie-tools/onie-tools/onie-bisdn-uninstall
+++ b/meta-mion/recipes-onie/onie-tools/onie-tools/onie-bisdn-uninstall
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# SPDX-License-Identifier: MIT
+
 set -e
 
 USAGE="Uninstall BISDN Linux

--- a/meta-mion/recipes-onie/onie-tools/onie-tools/onie-bisdn-upgrade
+++ b/meta-mion/recipes-onie/onie-tools/onie-tools/onie-bisdn-upgrade
@@ -3,6 +3,8 @@
 # Copyright (C) 2019 Daniel Fritzsche of BISDN GmbH
 # Bash script to upgrade BISDN Linux to a new image.
 
+# SPDX-License-Identifier: MIT
+
 set -e
 
 USAGE="Upgrade BISDN Linux

--- a/meta-mion/recipes-onie/onie-tools/onie-tools_1.0.bb
+++ b/meta-mion/recipes-onie/onie-tools/onie-tools_1.0.bb
@@ -1,5 +1,6 @@
 # Copyright (C) 2018 Tobias Jungel <tobias.jungel@bisdn.de>
 # Released under the MIT license (see COPYING.MIT for the terms)
+# SPDX-License-Identifier: MIT
 
 DESCRIPTION = "BISDN Linux ONIE tools"
 HOMEPAGE = "https://www.bisdn.de/"

--- a/meta-mion/recipes-platform/onlpv1/onlpv1_1.0.bb
+++ b/meta-mion/recipes-platform/onlpv1/onlpv1_1.0.bb
@@ -1,6 +1,8 @@
 # Copyright (C) 2018 Tobias Jungel <tobias.jungel@bisdn.de>
 # Released under the MIT license (see COPYING.MIT for the terms)
 
+# SPDX-License-Identifier: MIT
+
 DESCRIPTION = "Open Network Linux Components for Yocto integration"
 HOMEPAGE = "https://www.opennetlinux.org/"
 LICENSE = "EPLv1.0"


### PR DESCRIPTION
For all scripts/executables, and bb and bbappend files, spdx headers
needed to be added for license purposes.

This addresses: #2

Signed-off-by: Katrina Prosise <igorina@toganlabs.com>