### PR TITLE
Remove References to application and system profiles

### DIFF
--- a/meta-mion/conf/distro/mion.conf
+++ b/meta-mion/conf/distro/mion.conf
@@ -4,8 +4,7 @@ TCLIBCAPPEND = ""
 
 MAINTAINER = "Togán Labs <support@toganlabs.com>"
 
-# Use a reduced set of default distro vars. This can easily be overridden in
-# system or application profiles.
+# Use a reduced set of default distro vars.
 DISTRO_FEATURES_DEFAULT = " \
     acl alsa argp bluetooth ext2 ipv4 ipv6 largefile \
     usbhost xattr nfs zeroconf pci 3g nfc \


### PR DESCRIPTION
meta-mion/conf/distro/mion.conf had a comment reference on line 8 to
system and application profiles which was removed.

No other references to the profiles were found.

This addresses #27

Signed-off-by: Katrina Prosise <igorina@toganlabs.com>