### PR TITLE
mion-image-core.inc: Enable tpm2 utils

### DIFF
--- a/meta-mion/recipes-core/images/mion-image-core.inc
+++ b/meta-mion/recipes-core/images/mion-image-core.inc
@@ -31,6 +31,8 @@ IMAGE_INSTALL += " \
     ethtool \
     "
 
+IMAGE_INSTALL += "${@bb.utils.contains('MACHINE_FEATURES', 'tpm2', 'packagegroup-security-tpm2', '', d)}"
+
 IMAGE_FEATURES += "ssh-server-openssh"
 
 IMAGE_FEATURES_remove = "doc-pkgs"


### PR DESCRIPTION
This change seletively builds the tpm2 tools packagegroup for systems with
"tpm2" in MACHINE_FEATURES

Signed-off-by: John Toomey <john@toganlabs.com>