### PR TITLE
mion.conf: Clean up DISTRO_FEATURES in mion.conf

### DIFF
--- a/meta-mion/conf/distro/mion.conf
+++ b/meta-mion/conf/distro/mion.conf
@@ -3,13 +3,6 @@ DISTRO_VERSION = "Blasket-2020.12+snapshot"
 
 MAINTAINER = "Togán Labs <support@toganlabs.com>"
 
-# Use a reduced set of default distro vars. This can easily be overridden in
-# system or application profiles.
-DISTRO_FEATURES_DEFAULT = " \
-    acl alsa argp bluetooth ext2 ipv4 ipv6 largefile \
-    usbhost xattr nfs zeroconf pci 3g nfc \
-    "
-
 ONIE_FILES ??= "${MIONBASE}/meta-mion/files/"
 
 # Customisation
@@ -17,11 +10,20 @@ ROOT_HOME = "/root"
 COPY_LIC_MANIFEST = "0"
 COPY_LIC_DIRS = "0"
 
+# Distro features
+DISTRO_FEATURES_DEFAULT = "ext2 ipv6 usbhost nfs pci nfs systemd"
+DISTRO_FEATURES_remove += " alsa bluetooth opengl pcmcia wayland wifi x11  3g pulseaudio"
+
+DISTRO_FEATURES_BACKFILL_CONSIDERED = "gobject-introspection-data"
+BAD_RECOMMENDATIONS ?= "busybox-syslog"
+
 # Use systemd
-DISTRO_FEATURES_append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 VIRTUAL-RUNTIME_initscripts = ""
+VIRTUAL-RUNTIME_login_manager = "systemd"
+PREFERRED_PROVIDER_udev ?= "systemd"
+PREFERRED_PROVIDER_udev-utils ?= "systemd"
 
 # Prefer OCI implementations of container tools
 PREFERRED_PROVIDER_virtual/runc = "runc-opencontainers"
@@ -113,23 +115,6 @@ ERROR_QA = "dev-so debug-deps dev-deps debug-files arch pkgconfig la \
            "
 
 
-DISTRO_FEATURES_DEFAULT ?= "acl argp ext2 ipv4 ipv6 largefile nfs pci pcmcia systemd usbgadget usbhost xattr"
-
-VIRTUAL-RUNTIME_init_manager = "systemd"
-DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
-VIRTUAL-RUNTIME_initscripts = ""
-
-VIRTUAL-RUNTIME_login_manager = "systemd"
-PREFERRED_PROVIDER_udev ?= "systemd"
-PREFERRED_PROVIDER_udev-utils ?= "systemd"
-
-# Remove certain DISTRO_FEATURES
-DISTRO_FEATURES_BACKFILL_CONSIDERED = "gobject-introspection-data"
-DISTRO_FEATURES_remove = "alsa wifi 3g bluetooth irda nfc pulseaudio bluez5"
-
-DISTRO_FEATURES_DEFAULT ?= "acl argp ext2 ipv4 ipv6 largefile nfs pci pcmcia systemd usbgadget usbhost xattr"
-
-BAD_RECOMMENDATIONS ?= "busybox-syslog"
 
 # OELAYOUT_ABI allows us to notify users when the format of TMPDIR changes in
 # an incompatible way. Such changes should usually be detailed in the commit
@@ -146,5 +131,3 @@ INHERIT += "reproducible_build"
 
 BB_SIGNATURE_HANDLER ?= "OEEquivHash"
 BB_HASHSERVE ??= "auto"
-
-


### PR DESCRIPTION
Clean up the DISTRO_FEATURES settings in mion.conf based on the list of
current distro features in the latest Yocto manual

Signed-off-by: John Toomey <john@toganlabs.com>