### PR TITLE
Add dev-pkgs to fix onlpdump.py libs linking issue.

### DIFF
--- a/meta-mion/recipes-core/images/mion-image-core.inc
+++ b/meta-mion/recipes-core/images/mion-image-core.inc
@@ -36,6 +36,6 @@ IMAGE_INSTALL += " \
 
 IMAGE_INSTALL += "${@bb.utils.contains('MACHINE_FEATURES', 'tpm2', 'packagegroup-security-tpm2', '', d)}"
 
-IMAGE_FEATURES += "ssh-server-openssh"
+IMAGE_FEATURES += "ssh-server-openssh dev-pkgs"
 
 IMAGE_FEATURES_remove = "doc-pkgs"


### PR DESCRIPTION
libonlp links made in `do_install()` was not making it onto the image.

Adding dev-pkgs fixes this.

This addresses meta-mion #67

Signed-off-by: Katrina Prosise <igorina@toganlabs.com>