### PR TITLE
Initial dev image .inc file

### DIFF
--- a/meta-mion/recipes-core/images/mion-image-core.inc
+++ b/meta-mion/recipes-core/images/mion-image-core.inc
@@ -13,11 +13,9 @@ IMAGE_INSTALL += " \
 # Individual packages not in the packagegroups
 IMAGE_INSTALL += " \
     bind-utils \
-    binutils \
     bridge-utils \
     curl \
     dnsmasq \
-    dmidecode \
     efibootmgr \
     findutils \
     glibc \
@@ -33,7 +31,6 @@ IMAGE_INSTALL += " \
     parted \
     pciutils \
     rsync \
-    strace \
     tzdata \
     usbutils \
     util-linux-blkid \

--- a/meta-mion/recipes-core/images/mion-image-dev.inc
+++ b/meta-mion/recipes-core/images/mion-image-dev.inc
@@ -1,0 +1,15 @@
+SUMMARY = "mion dev packages"
+LICENSE = "MIT"
+
+IMAGE_INSTALL += " \
+    ccache \
+    dmidecode \
+    git \
+    kernel-devsrc \
+    m4 \
+    meson \
+    ninja \
+    packagegroup-core-buildessential \
+    packagegroup-core-tools-debug \
+    pkgconf \
+"


### PR DESCRIPTION
mion-image-dev.inc can be optionally included in any existing image in
order to install a number of development related tools which are not
appropriate to include in the default image.

Signed-off-by: John Toomey <john@toganlabs.com>