### PR TITLE
mion.conf: Switch to +snapshot DISTRO_VERSION

### DIFF
--- a/meta-mion/conf/distro/mion.conf
+++ b/meta-mion/conf/distro/mion.conf
@@ -1,5 +1,5 @@
 DISTRO_NAME = "mion (Mini Infrastructure OS for Networking)"
-DISTRO_VERSION = "Copeland-2021.03"
+DISTRO_VERSION = "Copeland-2021.03+snapshot"
 
 MAINTAINER = "Togán Labs <support@toganlabs.com>"
 


### PR DESCRIPTION
With Copeland out, we're now on +snapshot

Signed-off-by: Eilís Ní Fhlannagáin <pidge@toganlabs.com>