### PR TITLE
Add aliases script to /etc/profile.d/

### DIFF
--- a/meta-mion/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-mion/recipes-core/base-files/base-files_%.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://00-aliases.sh"
+
+do_install_append() {
+    install -d ${D}${sysconfdir}/profile.d/
+    install -m 0755 ${WORKDIR}/00-aliases.sh ${D}${sysconfdir}/profile.d/
+}
+
+#FILES_${PN} = "${sysconfdir}/profile.d"

--- a/meta-mion/recipes-core/base-files/files/00-aliases.sh
+++ b/meta-mion/recipes-core/base-files/files/00-aliases.sh
@@ -1,0 +1,3 @@
+alias ll='ls -l'
+
+[ -r /etc/bash_completion ] && . /etc/bash_completion


### PR DESCRIPTION
The contents of the profile.d directory is run by bash for login shells
(console and ssh) so we can add our aliases script here.

Signed-off-by: John Toomey <john@toganlabs.com>

# meta-mion

## Summary
- Description: This seems like the best place to add the bash settings so that it will work on all login shells and for all users
- Affected hardware: ALL
- Issue: #88

## Build and test
- [x] Build command: mc_build.sh -m stordis-bf2556x-1t -h host-onie:mion-onie-image-onlpv1
- [x] Smoke tested on: aps bf2556x-1t
- [ ] _all other steps taken to validate the pull request_
