### PR TITLE
Kprosise/ptest image

### DIFF
--- a/meta-mion/recipes-core/images/mion-image-onlpv1-ptest.bb
+++ b/meta-mion/recipes-core/images/mion-image-onlpv1-ptest.bb
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: MIT
+
+# Currently requires ptest to be set in local.conf as a member of
+# DISTRO_FEATURES, as is proper. However, we need to eventually have that setup
+# and working here.
+
+require mion-image-onlpv1.bb
+
+#DISTRO_FEATURES_append += " ptest"
+
+IMAGE_FEATURES += " ptest-pkgs"
+IMAGE_INSTALL += "ptest-runner"


### PR DESCRIPTION
# meta-mion

## Summary
- Description: added a preliminary ptest image type
- Affected hardware: n/a
- Issue: mion#81

## Build and test
- [ x] Build command: -v qemu -m qemux86-64 -h host-onie:mion-image-onlpv1-ptest
- [ x] Smoke tested on: qemu
- [ ] none

## Checklist
- [x] All relevant issues have been updated
- [x] Reviewers have been added and a maintainer has been assigned
- [x] A Label, Project and Milestone have all been added
- [ ] The relevant documentation/wiki/README have been updated and complies with the [NGL Style and Communication Guide](https://github.com/NetworkGradeLinux/mion-docs/wiki/Style-and-Communication-Guide)
- [ ] Git commits comply with the [NGL Git Workflow](https://github.com/NetworkGradeLinux/mion-docs/wiki/Git-Workflow) and have DCO signoff
- [x] Yocto code complies with the [OpenEmbedded Style Guide](https://www.openembedded.org/wiki/Styleguide)
