### PR TITLE
onlpdump.service: Reduce timeout on onlpd shutdown

### DIFF
--- a/meta-mion/recipes-platform/onlpv1/onlpv1/onlpdump.service
+++ b/meta-mion/recipes-platform/onlpv1/onlpv1/onlpdump.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 ExecStart=@BINDIR@/onlpd -M /run/onlpdump.pid
+TimeoutStopSec=1
 PIDFile=/run/onlpdump.pid
 Type=simple
 

--- a/meta-mion/recipes-platform/onlpv2/onlpv2/onlpdump.service
+++ b/meta-mion/recipes-platform/onlpv2/onlpv2/onlpdump.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 ExecStart=@BINDIR@/onlps -M /run/onlpdump.pid
+TimeoutStopSec=1
 PIDFile=/run/onlpdump.pid
 Type=simple
 


### PR DESCRIPTION
There does not appear to be a clean way to kill the onlpd service so it
hangs for 90 seconds on shutdown, after which, systemd kills it. This
patch reduces the timeout for systemdd to kill it quickly.

Signed-off-by: John Toomey <john@toganlabs.com>

# meta-mion

## Summary
- Description: _brief description of the bug that was fixed or the enhancement that was added_
- Affected hardware: _ALL -or- list specific switches_
- Issue: meta-mion-bsp#45

## Build and test
- [ ] Build command: ../mc_build.sh -m stordis-bf2556x-1t -h host-onie:mion-onie-image-onlpv1
- [ ] Smoke tested on:  stordis bf2556x-1t

