### PR TITLE
mion-image-core.inc: Add package-management

### DIFF
--- a/recipes-core/images/mion-image-core.inc
+++ b/recipes-core/images/mion-image-core.inc
@@ -47,6 +47,8 @@ IMAGE_FEATURES += "ssh-server-openssh dev-pkgs"
 
 IMAGE_FEATURES_remove = "doc-pkgs"
 
+EXTRA_IMAGE_FEATURES += " package-management"
+
 PREFERRED_PROVIDER_virtual/base-utils = "packagegroup-core-base-utils"
 VIRTUAL-RUNTIME_base-utils = "packagegroup-core-base-utils"
 VIRTUAL-RUNTIME_base-utils-hwclock = "util-linux-hwclock"


### PR DESCRIPTION
Signed-off-by: John Toomey <john@toganlabs.com>

# meta-mion

## Summary
- Description: add package management to all images - opkg
- Affected hardware: ALL
- Issue: meta-mion#117

## Build and test
- [x] Build command: ime ../cronie.sh -m stordis-bf2556x-1t mion-onie-image-onlpv1
- [ ] Smoke tested on: no