### PR TITLE
Allow additional image fstypes

### DIFF
--- a/conf/distro/mion.conf
+++ b/conf/distro/mion.conf
@@ -134,7 +134,7 @@ BB_HASHSERVE ??= "auto"
 
 IMAGE_FILE_EXTENSION = "tar.xz"
 
-IMAGE_FSTYPES = " \
+IMAGE_FSTYPES += " \
     ${IMAGE_FILE_EXTENSION} \
     ${IMAGE_FILE_EXTENSION}.bmap \
     "


### PR DESCRIPTION
To allow for image filesystem types other than `tar.xz`, the distro conf
file was changed to append rather than overwrite.

This commit closes meta-mion-bsp #51

Signed-off-by: Katrina Prosise <igorina@toganlabs.com>

# meta-mion

## Summary
- Description: Changed `IMAGE_FSTYPES` from assignment to append.
- Affected hardware: **All**
- Issue: This applies to meta-mion-bsp#51, as the change here will allow types defined in a bsp recipe
or elsewhere to be added

## Build and test
- [x] Build command: `../mc_build.sh -v qemu -m qemux86-64 -h host-onie:mion-image-onlpv1-ptest`
- [x] Smoke tested on: **qemux86-64**
- [ ] _all other steps taken to validate the pull request_

## Checklist
- [x] All relevant issues have been updated
- [x] Reviewers have been added and a maintainer has been assigned
- [x] A Label, Project and Milestone have all been added
- [x] The relevant documentation/wiki/README have been updated and complies with the [NGL Style and Communication Guide](https://github.com/NetworkGradeLinux/mion-docs/wiki/Style-and-Communication-Guide)
- [x] Git commits comply with the [NGL Git Workflow](https://github.com/NetworkGradeLinux/mion-docs/wiki/Git-Workflow) and have DCO signoff
- [ ] Yocto code complies with the [OpenEmbedded Style Guide](https://www.openembedded.org/wiki/Styleguide)
