### PR TITLE
mion.conf: Split distro version into vars

### DIFF
--- a/conf/distro/mion.conf
+++ b/conf/distro/mion.conf
@@ -1,5 +1,7 @@
 DISTRO_NAME = "mion (Mini Infrastructure OS for Networking)"
-DISTRO_VERSION = "Copeland-2021.03+snapshot"
+DISTRO_DATE = "2021.03"
+DISTRO_CODE = "Copeland"
+DISTRO_VERSION = "${DISTRO_CODE}-${DISTRO_DATE}+snapshot"
 
 MAINTAINER = "Togán Labs <support@toganlabs.com>"
 


### PR DESCRIPTION
Signed-off-by: John Toomey <john@toganlabs.com>

# meta-mion

## Summary
- Description: Split the distro string into component parts
- Affected hardware: ALL
- Issue: n/a

## Build and test
- [x] Build command: built all supported platforms
- [ ] Smoke tested on: no smoke test