### PR TITLE
Revert "Allow additional image fstypes"

### DIFF
--- a/conf/distro/mion.conf
+++ b/conf/distro/mion.conf
@@ -136,7 +136,7 @@ BB_HASHSERVE ??= "auto"
 
 IMAGE_FILE_EXTENSION = "tar.xz"
 
-IMAGE_FSTYPES += " \
+IMAGE_FSTYPES = " \
     ${IMAGE_FILE_EXTENSION} \
     ${IMAGE_FILE_EXTENSION}.bmap \
     "


### PR DESCRIPTION
Reverts NetworkGradeLinux/meta-mion#105

This causes CI to fail. We need to rethink how this is done.