### PR TITLE
mion-onie-image.inc: Don't do this as IMAGE_POSTPROCESS

### DIFF
--- a/recipes-onie/images/mion-onie-image-dent-initramfs.bb
+++ b/recipes-onie/images/mion-onie-image-dent-initramfs.bb
@@ -1,5 +1,14 @@
-include mion-onie-image-dent.bb 
+require mion-onie-image.inc
+require recipes-core/images/mion-image-core.inc
+ONLPV="dent"
+IMAGE_INSTALL += " \
+ ${ONLPV} \
+ packagegroup-onl-python2 \
+"
 
 IMAGE_FSTYPES += "${INITRAMFS_FSTYPES}"
 
-#PACKAGE_INSTALL += "${IMAGE_INSTALL}"
+PACKAGE_INSTALL += "${IMAGE_INSTALL}"
+
+INSTALL_FILE="${IMGDEPLOYDIR}/fitImage-${IMAGE_BASENAME}-${MACHINE}-${MACHINE}"
+

--- a/recipes-onie/images/mion-onie-image.inc
+++ b/recipes-onie/images/mion-onie-image.inc
@@ -11,10 +11,6 @@ SRC_URI = "file://grub-env/install.sh \
 
 IMAGE_FEATURES[validitems] += "secureboot"
 
-do_bundle[depends] += "mc::${MCNAME}:virtual/kernel:do_deploy"
-
-# Uncomment the following for initramfs only boot
-# INSTALL_TYPE = "initramfs"
 INSTALL_ROOTFS = "${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.tar.xz"
 INSTALL_KERNEL = "${DEPLOY_DIR_IMAGE}/bzImage"
 INSTALL_INITRD = "${IMGDEPLOYDIR}/${IMAGE_BASENAME}-${MACHINE}.cpio.gz"
@@ -46,7 +42,7 @@ python () {
         d.delVarFlag("do_unpack", "noexec")
 }
 
-do_bundle () {
+do_onie_bundle () {
     mkdir --parent "${ONIEIMAGE_DIR_INSTALL}"
 
     # Install script and install file depend on the ARCH
@@ -90,9 +86,9 @@ do_bundle () {
     cat "${ONIEIMAGE_PAYLOAD_FILE}" >> "${ONIEIMAGE_OUTPUT_FILE}"
     
     . ${ONIEIMAGE_MACHINE_CONF}
-    install -m 0644 ${ONIEIMAGE_OUTPUT_FILE} ${IMGDEPLOYDIR}/onie-installer-${PLATFORM}.bin
-    cd ${IMGDEPLOYDIR}
+    install -m 0644 ${ONIEIMAGE_OUTPUT_FILE} ${DEPLOY_DIR_IMAGE}/onie-installer-${PLATFORM}.bin
+    cd ${DEPLOY_DIR_IMAGE}
     ln -sf ./onie-installer-${PLATFORM}.bin ./onie-installer.bin
 }
 
-IMAGE_POSTPROCESS_COMMAND_append=" do_unpack; do_bundle; "
+addtask do_onie_bundle after do_image_complete before do_build


### PR DESCRIPTION
do_onie_bundle (which has been renamed from do_bundle) can't
do the fitImage assembly and the bundle. So we need to stick it
after do_image_complete is done.

Signed-off-by: Eilís Ní Fhlannagáin <pidge@toganlabs.com>

# meta-mion

## Summary
- Description: _brief description of the bug that was fixed or the enhancement that was added_
- Affected hardware: _ALL -or- list specific switches_
- Issue: _#?_

## Build and test
- [ ] Build command: _e.g. mc_build.sh ..._
- [ ] Smoke tested on: _e.g. stordis bf2556x-1t_
- [ ] _all other steps taken to validate the pull request_

## Checklist
- [ ] All relevant issues have been updated
- [ ] Reviewers have been added and a maintainer has been assigned
- [ ] A Label, Project and Milestone have all been added
- [ ] The relevant documentation/wiki/README have been updated and complies with the [NGL Style and Communication Guide](https://github.com/NetworkGradeLinux/mion-docs/wiki/Style-and-Communication-Guide)
- [ ] Git commits comply with the [NGL Git Workflow](https://github.com/NetworkGradeLinux/mion-docs/wiki/Git-Workflow) and have DCO signoff
- [ ] Yocto code complies with the [OpenEmbedded Style Guide](https://www.openembedded.org/wiki/Styleguide)
