### PR TITLE
mion-onie-image.inc: Require kernel to be deployed

### DIFF
--- a/recipes-onie/images/mion-onie-image.inc
+++ b/recipes-onie/images/mion-onie-image.inc
@@ -39,6 +39,8 @@ DEPENDS += "${@ "sbsigntool-native" if bb.utils.to_boolean(d.getVar('SECURE_BOOT
 IMAGE_FSTYPES += "tar.xz"
 IMAGE_FSTYPES += "${@ "cpio.gz" if bb.utils.to_boolean(d.getVar('SECURE_BOOT_ENABLED')) else "" }"
 
+do_onie_bundle[depends] += "virtual/kernel:do_deploy"
+
 do_onie_bundle () {
     mkdir --parent "${ONIEIMAGE_DIR_INSTALL}"
 


### PR DESCRIPTION
For initramfs the kernel needs to do the initramfs bundle
so we need it deployed before we can run do_onie_bundle

Signed-off-by: Eilís Ní Fhlannagáin <pidge@toganlabs.com>

# meta-mion

## Summary
- Description: _brief description of the bug that was fixed or the enhancement that was added_
- Affected hardware: _ALL -or- list specific switches_
- Issue: _#?_

## Build and test
- [ ] Build command: _e.g. mc_build.sh ..._
- [ ] Smoke tested on: _e.g. stordis bf2556x-1t_
- [ ] _all other steps taken to validate the pull request_

## Checklist
- [ ] All relevant issues have been updated
- [ ] Reviewers have been added and a maintainer has been assigned
- [ ] A Label, Project and Milestone have all been added
- [ ] The relevant documentation/wiki/README have been updated and complies with the [NGL Style and Communication Guide](https://github.com/NetworkGradeLinux/mion-docs/wiki/Style-and-Communication-Guide)
- [ ] Git commits comply with the [NGL Git Workflow](https://github.com/NetworkGradeLinux/mion-docs/wiki/Git-Workflow) and have DCO signoff
- [ ] Yocto code complies with the [OpenEmbedded Style Guide](https://www.openembedded.org/wiki/Styleguide)
