### PR TITLE
mion-image-core.inc: Add smarttools to default image

### DIFF
--- a/recipes-core/images/mion-image-core.inc
+++ b/recipes-core/images/mion-image-core.inc
@@ -33,6 +33,7 @@ IMAGE_INSTALL_append = " \
     pciutils \
     rsync \
     runc-opencontainers \
+    smartmontools \
     tmux \
     tree \
     tzdata \


### PR DESCRIPTION
Signed-off-by: John Toomey <john@toganlabs.com>

# meta-mion

## Summary
- Description: Add smartmontools
- Affected hardware: ALL
- Issue: none
