### PR TITLE
dent_1.0.bb: Add ifupdown2 as a DEPENDS

### DIFF
--- a/recipes-core/images/mion-image-dent.bb
+++ b/recipes-core/images/mion-image-dent.bb
@@ -1,4 +1,4 @@
 require mion-image-onlpv1.bb
 
 IMAGE_INSTALL_remove="onlpv1"
-IMAGE_INSTALL_append="dent ifupdown2"
+IMAGE_INSTALL_append="dent"

--- a/recipes-onie/images/mion-onie-image-dent-initramfs.bb
+++ b/recipes-onie/images/mion-onie-image-dent-initramfs.bb
@@ -3,7 +3,6 @@ require recipes-core/images/mion-image-core.inc
 ONLPV="dent"
 IMAGE_INSTALL += " \
  ${ONLPV} \
- ifupdown2 \
  packagegroup-onl-python2 \
 "
 

--- a/recipes-onie/images/mion-onie-image-dent.bb
+++ b/recipes-onie/images/mion-onie-image-dent.bb
@@ -4,6 +4,5 @@ require recipes-core/images/mion-image-core.inc
 ONLPV="dent"
 IMAGE_INSTALL_append = " \
     dent \
-    ifupdown2 \
     packagegroup-onl-python2 \
 "

--- a/recipes-platform/dent/dent_1.0.bb
+++ b/recipes-platform/dent/dent_1.0.bb
@@ -40,7 +40,7 @@ inherit systemd
 SYSTEMD_SERVICE_${PN} = "onlpdump.service"
 SYSTEMD_AUTO_ENABLE = "enable"
 
-DEPENDS = "i2c-tools python libedit libzip"
+DEPENDS = "ifupdown2 i2c-tools python libedit libzip"
 
 S = "${WORKDIR}/git"
 PV = "1.1+git${SRCPV}"


### PR DESCRIPTION
We really shouldn't need to call out ifupdown2 in the images,
it should be a depends in the dent recipe.

Signed-off-by: Eilís Ní Fhlannagáin <pidge@toganlabs.com>

