### PR TITLE
mion.conf: Bumping to Dernish release

### DIFF
--- a/conf/distro/mion.conf
+++ b/conf/distro/mion.conf
@@ -1,7 +1,7 @@
 DISTRO_NAME = "mion (Mini Infrastructure OS for Networking)"
-DISTRO_DATE = "2021.03"
-DISTRO_CODE = "Copeland"
-DISTRO_VERSION = "${DISTRO_CODE}-${DISTRO_DATE}+snapshot"
+DISTRO_DATE = "2021.06"
+DISTRO_CODE = "Dernish"
+DISTRO_VERSION = "${DISTRO_CODE}-${DISTRO_DATE}"
 
 MAINTAINER = "Togán Labs <support@toganlabs.com>"
 


### PR DESCRIPTION
Bumping DISTRO_VERSION for 2021.06

Signed-off-by: Eilís Ní Fhlannagáin <pidge@toganlabs.com>

# meta-mion

## Summary
- Description: _brief description of the bug that was fixed or the enhancement that was added_
- Affected hardware: _ALL -or- list specific switches_
- Issue: _#?_

## Build and test
- [ ] Build command: _e.g. mc_build.sh ..._
- [ ] Smoke tested on: _e.g. stordis bf2556x-1t_
- [ ] _all other steps taken to validate the pull request_

## Checklist
- [ ] All relevant issues have been updated
- [ ] Reviewers have been added and a maintainer has been assigned
- [ ] A Label, Project and Milestone have all been added
- [ ] The relevant documentation/wiki/README have been updated and complies with the [NGL Style and Communication Guide](https://github.com/NetworkGradeLinux/mion-docs/wiki/Style-and-Communication-Guide)
- [ ] Git commits comply with the [NGL Git Workflow](https://github.com/NetworkGradeLinux/mion-docs/wiki/Git-Workflow) and have DCO signoff
- [ ] Yocto code complies with the [OpenEmbedded Style Guide](https://www.openembedded.org/wiki/Styleguide)
