### PR TITLE
mion.conf: Remove NFS from DISTRO_FEATURES

### DIFF
--- a/conf/distro/mion.conf
+++ b/conf/distro/mion.conf
@@ -13,7 +13,7 @@ COPY_LIC_MANIFEST = "0"
 COPY_LIC_DIRS = "0"
 
 # Distro features
-DISTRO_FEATURES_DEFAULT = "ext2 ipv6 usbhost nfs pci nfs systemd"
+DISTRO_FEATURES_DEFAULT = "ext2 ipv6 usbhost pci systemd"
 DISTRO_FEATURES_remove += " alsa bluetooth opengl pcmcia wayland wifi x11  3g pulseaudio"
 
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "gobject-introspection-data"


### PR DESCRIPTION
The inclusion of NFS in distro features is installing a NFSD service
which is failing to start on boot due to a missing kernel modules - the
easiest thing to do is remove the distro feature which prevents the
service being installed.

Signed-off-by: John Toomey <john@toganlabs.com>

# repo: meta-mion

- Issue: #87 

- Affected hardware: ALL -or- _specific switches_
- Build command: cronie.sh -m stordis-bf2556x-1t mion-onie-image-onlpv1
- Tested on: bf2556

- Description: remove nfs to prevent boot error
